### PR TITLE
Add cors proxy

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "cors": "^2.8.5",
     "express": "^4.17.2",
     "form-data": "^4.0.0",
-    "node-fetch": "^3.1.0"
+    "node-fetch": "^3.1.0",
+    "request": "^2.88.2"
   },
   "devDependencies": {
     "@babel/preset-env": "^7.16.7",

--- a/src/app.js
+++ b/src/app.js
@@ -1,6 +1,7 @@
 import express from "express";
 import cors from "cors";
 import busboy from "connect-busboy";
+import request from 'request';
 
 const app = express();
 
@@ -21,6 +22,12 @@ app.use(busboy());
 
 app.get("/", (req, res) => {
   res.send("1.0.0");
+});
+
+app.get("/cors/*", function (req, res) {
+  request(req.url.substring(6), {json: true}, (err) => {
+    if (err) { return console.log(err); }
+  }).pipe(res);
 });
 
 app.put("/v1/daoAssets", catchAsync(daolistRoutes.putCreateAssets));


### PR DESCRIPTION
This service is needed to request data from discourse API, since usually discourse do not have CORS enabled.